### PR TITLE
Multiple ranges for months and days of week

### DIFF
--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/AbstractDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/AbstractDescriptionBuilder.java
@@ -29,11 +29,8 @@ public abstract class AbstractDescriptionBuilder {
             if (segments[0].contains("-")) {
                 String betweenSegmentOfInterval = segments[0];
                 String[] betweenSegments = betweenSegmentOfInterval.split("-");
-                description += ", " + MessageFormat.format(getBetweenDescriptionFormat(betweenSegmentOfInterval), getSingleItemDescription(betweenSegments[0]), getSingleItemDescription(betweenSegments[1]));
+                description += ", " + MessageFormat.format(getBetweenDescriptionFormat(betweenSegmentOfInterval, false), getSingleItemDescription(betweenSegments[0]), getSingleItemDescription(betweenSegments[1]));
             }
-        } else if (expression.contains("-")) {
-            String[] segments = expression.split("-");
-            description = MessageFormat.format(getBetweenDescriptionFormat(expression), getSingleItemDescription(segments[0]), getSingleItemDescription(segments[1]));
         } else if (expression.contains(",")) {
             String[] segments = expression.split(",");
             StringBuilder descriptionContent = new StringBuilder();
@@ -48,9 +45,17 @@ public abstract class AbstractDescriptionBuilder {
                     descriptionContent.append(I18nMessages.get("and"));
                     descriptionContent.append(" ");
                 }
-                descriptionContent.append(getSingleItemDescription(segments[i]));
+                if (segments[i].contains("-")) {
+                    String[] betweenSegments = segments[i].split("-");
+                    descriptionContent.append(MessageFormat.format(getBetweenDescriptionFormat(expression, true), getSingleItemDescription(betweenSegments[0]), getSingleItemDescription(betweenSegments[1])));
+                } else {
+                    descriptionContent.append(getSingleItemDescription(segments[i]));
+                }
             }
             description = MessageFormat.format(getDescriptionFormat(expression), descriptionContent.toString());
+        } else if (expression.contains("-")) {
+            String[] segments = expression.split("-");
+            description = MessageFormat.format(getBetweenDescriptionFormat(expression, false), getSingleItemDescription(segments[0]), getSingleItemDescription(segments[1]));
         }
         return description;
     }
@@ -59,7 +64,7 @@ public abstract class AbstractDescriptionBuilder {
      * @param expression
      * @return
      */
-    protected abstract String getBetweenDescriptionFormat(String expression);
+    protected abstract String getBetweenDescriptionFormat(String expression, boolean omitSeparator);
 
     /**
      * @param expression

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/DayOfMonthDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/DayOfMonthDescriptionBuilder.java
@@ -19,8 +19,9 @@ public class DayOfMonthDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
-        return ", "+I18nMessages.get("between_days_of_the_month");
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
+    	String format = I18nMessages.get("between_days_of_the_month");
+        return omitSeparator ? format : ", "+format;
     }
 
     @Override

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/DayOfWeekDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/DayOfWeekDescriptionBuilder.java
@@ -61,8 +61,9 @@ public class DayOfWeekDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
-        return ", "+I18nMessages.get("between_weekday_description_format");
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
+    	String format = I18nMessages.get("between_weekday_description_format");
+    	return omitSeparator ? format : ", "+format;
     }
 
     @Override

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/HoursDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/HoursDescriptionBuilder.java
@@ -30,7 +30,7 @@ public class HoursDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
         return I18nMessages.get("between_x_and_y");
     }
 

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/MinutesDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/MinutesDescriptionBuilder.java
@@ -22,7 +22,7 @@ public class MinutesDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
         return I18nMessages.get("minutes_through_past_the_hour");
     }
 

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/MonthDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/MonthDescriptionBuilder.java
@@ -24,8 +24,9 @@ public class MonthDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
-        return ", "+I18nMessages.get("between_description_format");
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
+    	String format = I18nMessages.get("between_description_format");
+        return omitSeparator ? format : ", "+format;
     }
 
     @Override

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/SecondsDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/SecondsDescriptionBuilder.java
@@ -21,7 +21,7 @@ public class SecondsDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
         return I18nMessages.get("seconds_through_past_the_minute");
     }
 

--- a/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/YearDescriptionBuilder.java
+++ b/cron-parser-core/src/main/java/net/redhogs/cronparser/builder/YearDescriptionBuilder.java
@@ -3,7 +3,6 @@ package net.redhogs.cronparser.builder;
 import java.text.MessageFormat;
 
 import net.redhogs.cronparser.I18nMessages;
-import net.redhogs.cronparser.Options;
 import org.joda.time.DateTime;
 
 /**
@@ -24,8 +23,9 @@ public class YearDescriptionBuilder extends AbstractDescriptionBuilder {
     }
 
     @Override
-    protected String getBetweenDescriptionFormat(String expression) {
-        return ", "+I18nMessages.get("between_description_format");
+    protected String getBetweenDescriptionFormat(String expression, boolean omitSeparator) {
+    	String format = I18nMessages.get("between_description_format");
+    	return omitSeparator ? format : ", "+format;
     }
 
     @Override

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorDETest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorDETest.java
@@ -172,6 +172,12 @@ public class CronExpressionDescriptorDETest {
   }
 
   @Test
+  public void testMonthNameRanges() throws Exception {
+    Assert.assertEquals("Um 3:00 AM, nur im Januar bis März und Mai bis Juni",
+        CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *", GERMAN));
+  }
+
+  @Test
   public void testDayOfWeekName() throws Exception {
     Assert.assertEquals("Um 12:23 PM, nur am Sonntag",
         CronExpressionDescriptor.getDescription("23 12 * * SUN", GERMAN));
@@ -185,6 +191,12 @@ public class CronExpressionDescriptorDETest {
         CronExpressionDescriptor.getDescription("*/5 15 * * 0-6", GERMAN));
     Assert.assertEquals("Alle 5 Minuten, um 3:00 PM, Samstag bis Sonntag",
         CronExpressionDescriptor.getDescription("*/5 15 * * 6-7", GERMAN));
+  }
+
+  @Test
+  public void testDayOfWeekRanges() throws Exception {
+    Assert.assertEquals("Um 3:00 AM, nur am Sonntag, Dienstag bis Donnerstag und Samstag",
+        CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6", GERMAN));
   }
 
   @Test

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorESTest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorESTest.java
@@ -133,6 +133,11 @@ public class CronExpressionDescriptorESTest {
     }
 
     @Test
+    public void testMonthNameRanges() throws Exception {
+        Assert.assertEquals("En 3:00 AM, sólo en enero hasta marzo y mayo hasta junio", CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *", SPANISH));
+    }
+
+    @Test
     public void testDayOfWeekName() throws Exception {
         Assert.assertEquals("En 12:23 PM, sólo en domingo", CronExpressionDescriptor.getDescription("23 12 * * SUN", SPANISH));
     }
@@ -142,6 +147,11 @@ public class CronExpressionDescriptorESTest {
         Assert.assertEquals("Cada 5 minutos, 3:00 PM, lunes hasta viernes", CronExpressionDescriptor.getDescription("*/5 15 * * MON-FRI", SPANISH));
         Assert.assertEquals("Cada 5 minutos, 3:00 PM, domingo hasta sábado", CronExpressionDescriptor.getDescription("*/5 15 * * 0-6", SPANISH));
         Assert.assertEquals("Cada 5 minutos, 3:00 PM, sábado hasta domingo", CronExpressionDescriptor.getDescription("*/5 15 * * 6-7", SPANISH));
+    }
+
+    @Test
+    public void testDayOfWeekRanges() throws Exception {
+        Assert.assertEquals("En 3:00 AM, sólo en domingo, martes hasta jueves y sábado", CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6", SPANISH));
     }
 
     @Test

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorITTest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorITTest.java
@@ -133,6 +133,11 @@ public class CronExpressionDescriptorITTest {
     }
 
     @Test
+    public void testMonthNameRanges() throws Exception {
+        Assert.assertEquals("Alle 3:00 AM, solo in gennaio fino a marzo e maggio fino a giugno", CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *", ITALIAN));
+    }
+
+    @Test
     public void testDayOfWeekName() throws Exception {
         Assert.assertEquals("Alle 12:23 PM, solo di domenica", CronExpressionDescriptor.getDescription("23 12 * * SUN", ITALIAN));
     }
@@ -142,6 +147,11 @@ public class CronExpressionDescriptorITTest {
         Assert.assertEquals("Ogni 5 minuti, 3:00 PM, lunedì fino a venerdì", CronExpressionDescriptor.getDescription("*/5 15 * * MON-FRI", ITALIAN));
         Assert.assertEquals("Ogni 5 minuti, 3:00 PM, domenica fino a sabato", CronExpressionDescriptor.getDescription("*/5 15 * * 0-6", ITALIAN));
         Assert.assertEquals("Ogni 5 minuti, 3:00 PM, sabato fino a domenica", CronExpressionDescriptor.getDescription("*/5 15 * * 6-7", ITALIAN));
+    }
+
+    @Test
+    public void testDayOfWeekRanges() throws Exception {
+        Assert.assertEquals("Alle 3:00 AM, solo di domenica, martedì fino a giovedì e sabato", CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6", ITALIAN));
     }
 
     @Test

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorNLTest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorNLTest.java
@@ -133,6 +133,11 @@ public class CronExpressionDescriptorNLTest {
     }
 
     @Test
+    public void testMonthNameRanges() throws Exception {
+        Assert.assertEquals("Om 3:00 AM, alleen in van januari tot maart en van mei tot juni", CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *", DUTCH));
+    }
+
+    @Test
     public void testDayOfWeekName() throws Exception {
         Assert.assertEquals("Om 12:23 PM, alleen op zondag", CronExpressionDescriptor.getDescription("23 12 * * SUN", DUTCH));
     }
@@ -142,6 +147,11 @@ public class CronExpressionDescriptorNLTest {
         Assert.assertEquals("Elke 5 minuten, om 3:00 PM, van maandag tot vrijdag", CronExpressionDescriptor.getDescription("*/5 15 * * MON-FRI", DUTCH));
         Assert.assertEquals("Elke 5 minuten, om 3:00 PM, van zondag tot zaterdag", CronExpressionDescriptor.getDescription("*/5 15 * * 0-6", DUTCH));
         Assert.assertEquals("Elke 5 minuten, om 3:00 PM, van zaterdag tot zondag", CronExpressionDescriptor.getDescription("*/5 15 * * 6-7", DUTCH));
+    }
+
+    @Test
+    public void testDayOfWeekRanges() throws Exception {
+        Assert.assertEquals("Om 3:00 AM, alleen op zondag, van dinsdag tot donderdag en zaterdag", CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6", DUTCH));
     }
 
     @Test

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorPTTest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorPTTest.java
@@ -145,15 +145,25 @@ public class CronExpressionDescriptorPTTest {
   }
 
   @Test
+  public void testMonthNameRanges() throws Exception {
+    Assert.assertEquals("Às 3:00 AM, em Janeiro até Março e Maio até Junho", CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *", PORTUGUESE));
+  }
+
+  @Test
   public void testDaeOfWeekName() throws Exception {
     Assert.assertEquals("Às 12:23, somente Domingo", CronExpressionDescriptor.getDescription("23 12 * * SUN", Options.twentyFourHour(), PORTUGUESE));
   }
 
   @Test
-  public void testDaeOfWeekRange() throws Exception {
+  public void testDayOfWeekRange() throws Exception {
     Assert.assertEquals("A cada 5 minutos, 15:00, Segunda-feira até Sexta-feira", CronExpressionDescriptor.getDescription("*/5 15 * * MON-FRI", Options.twentyFourHour(), PORTUGUESE));
     Assert.assertEquals("A cada 5 minutos, 15:00, Domingo até Sábado", CronExpressionDescriptor.getDescription("*/5 15 * * 0-6", Options.twentyFourHour(), PORTUGUESE));
     Assert.assertEquals("A cada 5 minutos, 15:00, Sábado até Domingo", CronExpressionDescriptor.getDescription("*/5 15 * * 6-7", Options.twentyFourHour(), PORTUGUESE));
+  }
+
+  @Test
+  public void testDayOfWeekRanges() throws Exception {
+    Assert.assertEquals("Às 3:00 AM, somente Domingo, Terça-feira até Quinta-feira e Sábado", CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6", PORTUGUESE));
   }
 
   @Test

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorROTest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorROTest.java
@@ -132,6 +132,11 @@ public class CronExpressionDescriptorROTest {
     }
 
     @Test
+    public void testMonthNameRanges() throws Exception {
+        Assert.assertEquals("La 3:00 AM, numai în din ianuarie până în martie și din mai până în iunie", CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *", ROMANIAN));
+    }
+
+    @Test
     public void testDayOfWeekName() throws Exception {
         Assert.assertEquals("La 12:23 PM, numai duminică", CronExpressionDescriptor.getDescription("23 12 * * SUN", ROMANIAN));
     }
@@ -141,6 +146,11 @@ public class CronExpressionDescriptorROTest {
         Assert.assertEquals("La fiecare 5 minute, la 3:00 PM, de luni până vineri", CronExpressionDescriptor.getDescription("*/5 15 * * MON-FRI", ROMANIAN));
         Assert.assertEquals("La fiecare 5 minute, la 3:00 PM, de duminică până sâmbătă", CronExpressionDescriptor.getDescription("*/5 15 * * 0-6", ROMANIAN));
         Assert.assertEquals("La fiecare 5 minute, la 3:00 PM, de sâmbătă până duminică", CronExpressionDescriptor.getDescription("*/5 15 * * 6-7", ROMANIAN));
+    }
+
+    @Test
+    public void testDayOfWeekRanges() throws Exception {
+        Assert.assertEquals("La 3:00 AM, numai duminică, de marţi până joi și sâmbătă", CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6", ROMANIAN));
     }
 
     @Test

--- a/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorTest.java
+++ b/cron-parser-core/src/test/java/net/redhogs/cronparser/CronExpressionDescriptorTest.java
@@ -141,6 +141,11 @@ public class CronExpressionDescriptorTest {
     }
 
     @Test
+    public void testMonthNameRanges() throws Exception {
+        Assert.assertEquals("At 3:00 AM, only in January through March and May through June", CronExpressionDescriptor.getDescription("0 0 3 * 1-3,5-6 *"));
+    }
+
+    @Test
     public void testDayOfWeekName() throws Exception {
         Assert.assertEquals("At 12:23 PM, only on Sunday", CronExpressionDescriptor.getDescription("23 12 * * SUN"));
     }
@@ -150,6 +155,11 @@ public class CronExpressionDescriptorTest {
         Assert.assertEquals("Every 5 minutes, at 3:00 PM, Monday through Friday", CronExpressionDescriptor.getDescription("*/5 15 * * MON-FRI"));
         Assert.assertEquals("Every 5 minutes, at 3:00 PM, Sunday through Saturday", CronExpressionDescriptor.getDescription("*/5 15 * * 0-6"));
         Assert.assertEquals("Every 5 minutes, at 3:00 PM, Saturday through Sunday", CronExpressionDescriptor.getDescription("*/5 15 * * 6-7"));
+    }
+
+    @Test
+    public void testDayOfWeekRanges() throws Exception {
+        Assert.assertEquals("At 3:00 AM, only on Sunday, Tuesday through Thursday and Saturday", CronExpressionDescriptor.getDescription("0 0 3 * * 0,2-4,6"));
     }
 
     @Test


### PR DESCRIPTION
Hi!

This patch is for formatting multiple ranges, e.g. monday to wednesday and thursday to saturday.

AbstractDescriptionBuilder.getBetweenDescriptionFormat needed an extra parameter to omit the comma, otherwise the output would contain double separators.
